### PR TITLE
2016 docker dev and Deis deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:3.3
 EXPOSE 80
 RUN apk add --update nginx && rm -rf /var/cache/apk/*
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY . /usr/share/nginx/html
+COPY build/ /usr/share/nginx/html
 CMD ["nginx"]

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,4 @@
+FROM mhart/alpine-node:5.10.1
+
+COPY package.json /
+RUN npm install

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,5 @@ push-private-registry:
 
 deis-pull-private:
 	deis pull ${DEIS_APP}:${VERSION} -a ${DEIS_APP}
+
+build-deploy: build-build-image build build-deploy-image push-private-registry deis-pull-private

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
+REGISTRY ?= quay.io/
+IMAGE_PREFIX ?= mozmar
+IMAGE_NAME ?= viewsourceconf
+IMAGE := ${REGISTRY}${IMAGE_PREFIX}/${IMAGE_NAME}\:${VERSION}
+BUILD_IMAGE_NAME ?= ${IMAGE_NAME}_build
+BUILD_IMAGE := ${REGISTRY}${IMAGE_PREFIX}/${BUILD_IMAGE_NAME}\:${VERSION}
+WATCH_PORT ?= 8080
+SERVE_PORT ?= 8000
+MOUNT_DIR ?= $(shell pwd)
+APP_DIR ?= /app
+DOCKER_RUN_ARGS ?= -v ${MOUNT_DIR}\:${APP_DIR} -w ${APP_DIR}
+HOST_IP ?= $(shell docker-machine ip || echo 127.0.0.1)
+
+.PHONY: build watch
+
+build:
+	docker run ${DOCKER_RUN_ARGS} ${BUILD_IMAGE} node build
+
+watch:
+	docker run ${DOCKER_RUN_ARGS} -p "${WATCH_PORT}:${WATCH_PORT}" ${BUILD_IMAGE} node watch 
+
+build-build-image:
+	docker build -f Dockerfile-build -t ${BUILD_IMAGE} .
+
+push-build-image:
+	docker push ${BUILD_IMAGE}
+
+build-deploy-image:
+	docker build -t ${IMAGE} .
+
+push-deploy-image:
+	docker push ${IMAGE}
+
+serve:
+	docker run -p "${SERVE_PORT}:80" ${IMAGE}
+
+curl:
+	curl -H "X-Forwarded-Proto: https" ${HOST_IP}:${SERVE_PORT}

--- a/watch.js
+++ b/watch.js
@@ -12,6 +12,7 @@ const watch = require('metalsmith-watch');
 
 metalsmith(__dirname)
     .source('source')
+    .use(debug())
     .use(ignore([
         '*swp',
     ]))
@@ -42,6 +43,15 @@ metalsmith(__dirname)
         })
     )
     .destination('build')
+    .use(watch({
+        pattern: '**/*',
+        livereload: true,
+    }))
+    .use(serve({
+        host: '0.0.0.0',
+        port: 8080,
+        verbose: true,
+    }))
     .build(function(err) {
         if (err) {
             console.log(err);


### PR DESCRIPTION
Replaces #35. I've reconfigured https://ci.us-west.moz.works/view/viewsourceconf/job/viewsourceconf_deploy_stage/ to build and deploy to https://viewsourceconf-stage.us-west.moz.works from the 2016 branch, so when this merges it should trigger a new deploy, as will all subsequent pushes to this branch.