### PR TITLE
Fix speaker_close button

### DIFF
--- a/source/js/speakers.js
+++ b/source/js/speakers.js
@@ -16,7 +16,10 @@
         button.setAttribute('aria-controls', speakerId + '_info');
         button.setAttribute('aria-expanded', 'false');
         button.classList.add('speaker_close');
-        button.appendChild(document.createTextNode('Return to speaker list.'));
+        var buttonText = document.createElement('span');
+        buttonText.classList.add('invisible');
+        buttonText.appendChild(document.createTextNode('Return to speaker list.'));
+        button.appendChild(buttonText);
         //add listenter
         button.addEventListener('click', function() {
             speakerClose(speakerId);

--- a/source/stylesheets/components/speakers.styl
+++ b/source/stylesheets/components/speakers.styl
@@ -100,6 +100,7 @@ speakers
     top: $grid-gutter-width;
     right: $grid-gutter-width;
     height: 40px;
+    min-width: 0;
     width: 0px;
     overflow: hidden;
     border: 1px solid $seattle-text;
@@ -118,7 +119,7 @@ speakers
     &::after {
         content: '\D7';
         position: absolute;
-        top: 4px;
+        top: -14px;
         left: 0;
         font-family: 'Courier New', Courier, 'Lucida Sans Typewriter', 'Lucida Typewriter', monospace;
         font-size: 69px;

--- a/source/stylesheets/includes/extends.styl
+++ b/source/stylesheets/includes/extends.styl
@@ -10,6 +10,19 @@ $clearfix {
 
 /*
 ====================================================================== */
+$a11y-hidden {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    padding: 0;
+    border: 0;
+}
+
+/*
+====================================================================== */
 @media print {
     $print-no {
         display: none !important;

--- a/source/stylesheets/includes/mixins.styl
+++ b/source/stylesheets/includes/mixins.styl
@@ -31,19 +31,6 @@ set-font-size(value) {
 
 /*
 ====================================================================== */
-a11y-hidden() {
-    position: absolute !important;
-    height: 1px;
-    width: 1px;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    padding: 0;
-    border: 0;
-}
-
-/*
-====================================================================== */
 heading-major() {
     margin: 0 0 $grid-gutter-width 0;
     font-family: $heading-font-family;

--- a/source/stylesheets/utilities/invisible.styl
+++ b/source/stylesheets/utilities/invisible.styl
@@ -1,11 +1,7 @@
-@require 'variables';
+@require 'extends';
 /*
 ====================================================================== */
 
 .invisible {
-    position: absolute !important;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;
-    clip: rect(1px, 1px, 1px, 1px);
+    @extends $a11y-hidden;
 }


### PR DESCRIPTION
Re-overriding default button styles.

Decided a11y-hidden was better off as an extend than a mixin.