### PR TITLE
Remove non functional woff2 type, fix typo in STS.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,11 +29,7 @@ http {
             add_header Cache-Control "public";
         }
 
-        location ~* \.(woff2)$ {
-            types {font/woff2 woff2;}
-        }
-
-        add_header Strict-Transport-Security: max-age=31536000;
+        add_header Strict-Transport-Security max-age=31536000;
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Woff2 declaration didn't work, need to find a way to change the mime.types apparently. Removing non functional code.

Fix typo on the STS line.