### PR TITLE
Tweaks for conference landing page session display.

### DIFF
--- a/data/conferences.json
+++ b/data/conferences.json
@@ -10,7 +10,7 @@
     ],
     "folder": "/berlin-2016",
     "speakers": true,
-    "schedule": false,
+    "schedule": true,
     "venue": true,
     "cfp": false,
     "sessions": true,

--- a/layouts/conference.html
+++ b/layouts/conference.html
@@ -61,7 +61,12 @@
                 <div class="solo">
                     <h2>Speakers</h2>
 
-                    <p>View Source features 16 world-class speakers (plus discussions and Q&amp;A breakouts), exposing best practices and new technologies. Check out our confirmed speakers below, and <a href="#newsletter" title="Get email updates">stay tuned</a> for upcoming additions to our stellar lineup.</p>
+                    <p>View Source features 16 world-class speakers (plus
+                        discussions and Q&amp;A breakouts), exposing best
+                        practices and new technologies. Check out our keynote
+                        speakers below, <a href="schedule/">see the full
+                        schedule</a>, and <a href="#newsletter">sign up for speaker
+                        announcements</a>.</p>
                 </div>
             </div>
         </div>
@@ -86,28 +91,33 @@
                                     </div>
 
                                     <div class="col speaker_text">
+                                        {% set showbio = true %}
                                         {% if speaker.sessions.length > 0 %}
                                             {% for session in model.sessions %}
                                                 {% for session_speaker in session.speakers %}
                                                     {% if session_speaker == speaker.slug %}
                                                         <h4 class="speaker_title">{{ session.title }}</h4>
-                                                        {% if session.summary.indexOf('<p>') === 0 %}
-                                                            {{ session.summary }}
-                                                        {% else %}
-                                                            <p>{{ session.summary }}</p>
+                                                        {% if session.summary %}
+                                                            {% set showbio = false %}
+                                                            {% if session.summary.indexOf('<p>') === 0 %}
+                                                                {{ session.summary }}
+                                                            {% else %}
+                                                                <p>{{ session.summary }}</p>
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% endif %}
                                                 {% endfor %}
                                             {% endfor %}
-                                            <a href="{{ conference_data.folder }}/speakers/{{ speaker.slug }}/">Read more about {{ speaker.first }}</a>
-                                        {% else %}
+                                        {% endif %}
+                                        {% if showbio %}
                                             {% if speaker.bio.indexOf('<p>') === 0 %}
                                                 {{ speaker.bio }}
                                             {% else %}
                                                 <p>{{ speaker.bio }}</p>
                                             {% endif %}
+                                        {% else %}
+                                            <a href="{{ conference_data.folder }}/speakers/{{ speaker.slug }}/">Read more about {{ speaker.first }}</a>
                                         {% endif %}
-
                                     </div>
                                 </div>
                             </div>
@@ -123,24 +133,29 @@
 {% if conference_data.sessions && model.sessions.length > 0 %}
     <section class="section section-grid" id="sessions">
         <div class="section_body">
-            <h2 class="center">Schedule</h2>
-
-            {% for day in conference_data.days %}
-                {% if ! loop.first %}
-                    <section id="{{day}}" class="session_day">
-                        <h3 class="section-invert session_day_header">
-                            <span class="session_day_header_date">{{ day|date(date_format) }}</span>
-                        </h3>
-                        {% for session in model.sessions %}
-                            {% if session.date == day && session.feature %}
-                                {% include "includes/session.html" with session %}
-                            {% endif %}
-                        {% endfor %}
-                    <p class="center"><a href="{{ conference_data.folder }}/schedule/" class="button">See full schedule</a></p>
-                    </section>
-                {% endif %}
-            {% endfor %}
-
+            <h2 class="center">Sessions</h2>
+            <div class="cols cols-half">
+                {% for day in conference_data.days %}
+                    {% if ! loop.first %}
+                        <div class="col">
+                            <section id="{{day}}" class="session_day">
+                                <h3 class="section-invert session_day_header">
+                                    <span class="session_day_header_date">{{ day|date(date_format) }}</span>
+                                </h3>
+                                {% for session in model.sessions %}
+                                    {% if session.date == day && session.feature %}
+                                        {% include "includes/sessionteaser.html" with session %}
+                                    {% endif %}
+                                {% endfor %}
+                            </section>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <div class="solo">
+                <p>View Source is equal parts sharing, learning, and meeting new people. Discuss and collaborate in an on-going hacking space, chill in comfy hangout spots, see some great demos, and participate in engaging discussions. Evening activities will provide a fun, friendly space to continue the conversation and start new ones.</p>
+            </div>
+            <p class="center"><a href="{{ conference_data.folder }}/schedule/" class="button">See full schedule</a></p>
         </div>
     </section>
 {% endif %}

--- a/layouts/includes/header.html
+++ b/layouts/includes/header.html
@@ -19,7 +19,7 @@
                     <li><a href="{{ conference_data.folder }}/#speakers">Speakers</a></li>
                 {% endif %}
                 {% if conference_data.schedule %}
-                    <li><a href="{{ conference_data.folder }}/#schedule">Schedule</a></li>
+                    <li><a href="{{ conference_data.folder }}/schedule/">Schedule</a></li>
                 {% endif %}
                 {% if conference_data.venue %}
                     <li><a href="{{ conference_data.folder }}/#venue">Venue</a></li>

--- a/layouts/includes/session.html
+++ b/layouts/includes/session.html
@@ -37,6 +37,7 @@
                             {% endif %}
                             {{ session.title }}{% if session.summary != "" %} • <a href="#{{ session.slug }}">More&nbsp;&hellip;</a>{% endif %}
                         </h4>
+                    {% if session.summary %}    
                     <div class="session_summary">
                         {% if session.summary.indexOf('<p>') === 0 %}
                             {% autoescape false %}{{ session.summary }}{% endautoescape %}
@@ -44,6 +45,7 @@
                             {% autoescape false %}<p>{{ session.summary }}</p>{% endautoescape %}
                         {% endif %}
                     </div>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/layouts/includes/sessionteaser.html
+++ b/layouts/includes/sessionteaser.html
@@ -1,0 +1,43 @@
+<div class="sessionteaser" id="{{ session.slug }}-teaser">
+    <div class="sidecol">
+        <div class="sidecol_side">
+            {% if session.speakers %}
+                <div class="sessionteaser_pic">
+                    {% for session_speaker in session.speakers %}
+                        {% for speaker in model.speakers %}
+                            {% if session_speaker == speaker.slug %}
+                                {% if speaker.pic %}
+                                <a href="{{ conference_data.folder }}/speakers/{{speaker.slug}}"><img src="/assets/images/speakers/{{ speaker.pic }}" height="400" width="400"></a>
+                                {% endif %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="sidecol_body">
+            {% if session.speakers.length == 0 %}
+                <h4 class="sessionteaser_head">{{ session.title }}</h4>
+            {% else %}
+                <h4 class="sessionteaser_head">
+                    {% if session.speakers %}
+                        <span class="sessionteaser_speakers">
+                            {% for session_speaker in session.speakers %}
+                                {% for speaker in model.speakers %}
+                                    {% if session_speaker == speaker.slug %}
+                                        <a href="{{ conference_data.folder }}/speakers/{{ speaker.slug }}" class="sessionteaser_speaker">{{ speaker.first }} {{ speaker.last }}</a>
+                                    {% endif %}
+                                {% endfor %}
+                            {% endfor %}
+                        </span>
+                    {% endif %}
+
+                </h4>
+                <p class="sessionteaser_title">
+                    {{ session.title }}{% if session.summary != "" %} • <a href="{{ conference_data.folder }}/schedule#{{ session.slug }}">More&nbsp;&hellip;</a>{% endif %}
+                </p>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "metalsmith-uglify": "^1.2.1",
     "metalsmith-watch": "^1.0.1",
     "mocha": "^2.4.5",
-    "selenium-webdriver": "^2.53.2",
+    "selenium-webdriver": "^2.53.3",
     "stylus": "^0.54.2",
     "swig": "^1.4.2"
   },

--- a/source/stylesheets/base/elements/document.styl
+++ b/source/stylesheets/base/elements/document.styl
@@ -1,3 +1,4 @@
+@require '../../includes/variables';
 /*
 document elements
 ====================================================================== */
@@ -9,5 +10,5 @@ html {
 body {
     scroll-behavior: smooth;
     font-family: $body-font-family;
-    line-height: 2.1em;
+    line-height: $body-line-height;
 }

--- a/source/stylesheets/base/elements/typography.styl
+++ b/source/stylesheets/base/elements/typography.styl
@@ -16,7 +16,7 @@ h3, h4, h5, h6 {
     margin: 0 0 $grid-gutter-width;
     padding: 0.2em 0; // padding tries to mimic line height on regular text
     font-weight: bold;
-    line-height: 1.5;
+    line-height: $heading-line-height;
 }
 
 h1 {

--- a/source/stylesheets/components/sessionteaser.styl
+++ b/source/stylesheets/components/sessionteaser.styl
@@ -1,0 +1,97 @@
+@require 'includes/variables'
+@require 'includes/extends'
+/*
+sessionteaser
+====================================================================== */
+
+$sessionteaser_image = 100px;
+
+.sessionteaser {
+    min-height: $sessionteaser_image;
+    padding: $grid-gutter-width;
+    margin-bottom: ($grid-gutter-width / 2);
+    @extends $clearfix
+
+    theme({
+        background-color: $theme-background
+    })
+}
+
+.sessionteaser .sidecol_side {
+    width: $sessionteaser_image;
+}
+
+.sessionteaser_pic {
+    display: flex;
+    width: $sessionteaser_image;
+    margin-bottom: 10px;
+
+    > a {
+        min-width: 0; /* http://stackoverflow.com/questions/31967019/max-width-doesnt-work-in-flexbox  */
+    }
+}
+
+.sessionteaser_head {
+    margin-top: -0.3em; /* makes it even with top of image */
+    margin-bottom: 0;
+    padding: 0;
+}
+
+.sessionteaser_speakers {
+    display: block;
+}
+
+.sessionteaser_speaker {
+    display: block;
+}
+
+.sessionteaser_title {
+    margin-bottom: 0;
+    line-height: 1.24;
+}
+
+@media $media-query-320-and-up {
+    .sessionteaser_pic {
+        float: right;
+        flex-direction: column;
+        margin-left: $grid-gutter-width;
+    }
+}
+
+@media $media-query-680-and-up {
+    .sessionteaser_speaker {
+        display: inline;
+
+        &::before {
+            content: "• ";
+            theme({
+                color: $theme-text
+            })
+        }
+
+        &:first-child::before {
+            content: "";
+        }
+    }
+
+    .sessionteaser_pic {
+        float: none;
+        width: auto;
+        flex-direction: row;
+        margin: 0;
+    }
+}
+
+@media $media-query-960-and-up {
+    .sessionteaser {
+        padding: $grid-gutter-width;
+    }
+
+    .sessionteaser .sidecol_side {
+        margin-right: $grid-gutter-width;
+    }
+
+    .sessionteaser_title {
+        line-height: $heading-line-height;
+    }
+}

--- a/source/stylesheets/includes/variables.styl
+++ b/source/stylesheets/includes/variables.styl
@@ -131,7 +131,9 @@ $theme-fade = {
 typography
 ====================================================================== */
 $heading-font-family = 'Moon Light', 'Lucida Grande', Tahoma, sans-serif;
+$heading-line-height = 1.5;
 $body-font-family = 'Montserrat Light', Geneva, 'Trebuchet MS', sans-serif;
+$body-line-height = 2.1;
 
 /*
 breakpoints & media queries

--- a/source/stylesheets/style.styl
+++ b/source/stylesheets/style.styl
@@ -41,6 +41,7 @@ BEM inspired naming please:
 ---------------------------------------------------------------------- */
 @require 'components/form';
 @require 'components/session';
+@require 'components/sessionteaser';
 @require 'components/speakers';
 @require 'components/frame';
 @require 'components/button';
@@ -54,5 +55,3 @@ BEM inspired naming please:
 @require 'components/sponsors';
 @require 'components/indent';
 @require 'components/strip';
-
-

--- a/source/stylesheets/utilities/sidecol.styl
+++ b/source/stylesheets/utilities/sidecol.styl
@@ -24,27 +24,8 @@ sidecol
     }
 }
 
-
-@supports (display:flex) {
-    .sidecol {
-        display: flex;
-    }
-
-    .sidecol,
-    .sidecol_body {
-        overflow: visible;
-    }
-
-    .sidecol_side {
-        float: none;
-    }
-
-}
-
-
 @media $media-query-960-and-up {
     .sidecol_side {
         margin-right: $grid-gutter-width-wide;
     }
 }
-


### PR DESCRIPTION
- Session list on home page is two columns
- Add schedule link to header
- Update copy to indicate featured speakers are keynotes
- Add teaser widget for sessions
- Remove flex-box cleverness for .sidecol