### PR TITLE
Remove link to Berlin home page.

### DIFF
--- a/layouts/includes/header.html
+++ b/layouts/includes/header.html
@@ -27,10 +27,6 @@
                 {% if conference_data.sponsor_prospectus %}
                     <li><a href="{{ conference_data.folder }}/#sponsor">Sponsor</a></li>
                 {% endif %}
-                {# Add a breadcrumb to the conference landing if the path has > 1 node #}
-                {% if path.split('/').length > 1 %}
-                    <li class="header_crumb"><a href="{{ conference_data.folder }}">View Source {{ conference_data.location }}</a></li>
-                {% endif %}
             </ul>
         {% endif %}
     </div>


### PR DESCRIPTION
As part of the work to make Berlin the home page for everything.