### PR TITLE
Improve schedule display

### DIFF
--- a/data/berlin_sessions.json
+++ b/data/berlin_sessions.json
@@ -6,7 +6,8 @@
         "date": "2016-09-12",
         "place": "",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "ignite-talks",
@@ -15,7 +16,8 @@
         "date": "2016-09-12",
         "place": "",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "welcome-reception",
@@ -24,7 +26,8 @@
         "date": "2016-09-12",
         "place": "",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "opening-keynote",
@@ -33,7 +36,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": true
     },
     {
         "slug": "design-for-non-designers",
@@ -43,7 +47,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>Not everyone can hire a professional designer for their websites and web apps, but we all still want our interfaces to be easy to use and attractive. However, if you want to learn a bit of design, design books jump straight into concepts like \"the golden ratio\" and teach proper typographic terms which, to be frank, aren't needed if you're just looking to improve your website's look and feel.</p><p>This talk will cover the top quick ways to improve your website, covering both user experience as well as visual design. Quick hits, easy to understand and utilize principles that anyone can use to improve their design skills. Perhaps you too can become the next designer+developer unicorn!</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "inclusive-markup",
@@ -53,14 +58,16 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>Accessibility is the law and a good idea. Let's make the Web accessible and fast for everyone. We'll skip \"why\" and focus on \"how.\" Accessibility can be as simple as using the right semantic elements in your HTML. Semantic HTML can prevent bugs, improve performance, reduce code bloat, and make your site accessible to screen readers and keyboard users. We'll explores accessibility features native to semantic elements, adding a sprinkling of ARIA roles and attributes. Form controls, input masking, styleable selects, and carousels with a few lines of CSS, fewer lines of JS and no frameworks.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "break",
         "title": "Break",
         "start": "11:00",
         "date": "2016-09-13",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "css-framework",
@@ -70,7 +77,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>Nowadays it is very common to find CSS frameworks like Bootstrap used everywhere. But they come at a cost, paid in big CSS files, styles that don't get used, and a hard to maintain code base.  </p><p>In this presentation we will talk about why using a third-party framework might not be the right choice for your project, be it a theme or a custom website. We will also see techniques to craft a blog theme without frameworks, from layout to individual UI components.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "node-releases",
@@ -80,7 +88,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>Node.js is growing up, and with that comes the responsibility of proper legacy support. As of Node.js Argon (v4.2.0) there is an official Long Term Support release cycle that lasts for 30 months!</p><p>How does a project moving at the pace of node maintain multiple release lines? How does a commit get backported? How is a release actually made? You will learn all this and more on this weeks episode of \"Node.js Releases, how do they work?\"</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "typography",
@@ -90,14 +99,16 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>As front end developers, we <em>own</em> performance. As designers, we own typography. So how do you handle the tricky intersection of beautiful web typography and performant web pages? I'll be showing the audience OpenType features, explaining why they're important to typefaces, and explaining the tradeoffs they have on performance. We'll go over how to enable OpenType features and how you can optimize your font files for the web whether you own them and serve them up through @font-face or through Typekit so you can feel confident serving up gorgeous typography on your sites.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "lunch",
         "title": "Lunch",
         "start": "13:00",
         "date": "2016-09-13",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "pwa-hack-corner-1",
@@ -106,7 +117,8 @@
         "date": "2016-09-13",
         "place": "Ground Floor: Discussion corner D - Saal (Social room)",
         "summary": "<p>Bring your laptop on Tuesday to learn about core PWA technologies such as Service Workers, the Web Manifest and Push notifications and join us on Wednesday in an open discussion session about the future of the Web.</p>",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "diversity-in-tech-1",
@@ -115,7 +127,8 @@
         "date": "2016-09-13",
         "place": "1st Floor: Discussion corner A - (Atelier A)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "sustainable-oss-1",
@@ -124,7 +137,8 @@
         "date": "2016-09-13",
         "place": "2nd Floor: Discussion corner B - (Kubus)",
         "summary": "<p>A lot of people enjoy contributing to Open Source projects. And Open Source projects love contributions. And yet we keep seeing newcomers struggling to contribute and project maintainers struggling to find contributors. What’s the catch? Let’s talk!</p>",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "aframe-workshop-1",
@@ -133,7 +147,8 @@
         "date": "2016-09-13",
         "place": "4th Floor Discussion corner C (Studio C)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "rust-discussion-1",
@@ -142,7 +157,8 @@
         "date": "2016-09-13",
         "place": "4th Floor Discussion corner E - (Studio B)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "diversity-in-tech-2",
@@ -151,7 +167,8 @@
         "date": "2016-09-13",
         "place": "1st Floor: Discussion corner A - (Atelier A)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "sustainable-oss-2",
@@ -160,7 +177,8 @@
         "date": "2016-09-13",
         "place": "2nd Floor: Discussion corner B - (Kubus)",
         "summary": "<p>A lot of people enjoy contributing to Open Source projects. And Open Source projects love contributions. And yet we keep seeing newcomers struggling to contribute and project maintainers struggling to find contributors. What’s the catch? Let’s talk!</p>",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "aframe-workshop-2",
@@ -169,7 +187,8 @@
         "date": "2016-09-13",
         "place": "4th Floor Discussion corner C (Studio C)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "rust-discussion-2",
@@ -178,14 +197,16 @@
         "date": "2016-09-13",
         "place": "4th Floor Discussion corner E - (Studio B)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "break",
         "title": "Break",
         "start": "15:30",
         "date": "2016-09-13",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "es6",
@@ -195,7 +216,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>ES6 and ES7 introduce many new features and capabilities to the JavaScript language. And yet, the majority of these enhancements are essentially syntactic sugar over the previous version. This is why tools like Babel are able to convert ES6 code into ES5. But there are several new features that can't be implemented in ES5.</p><p>In this session I'll explain what these new features are, what they do, and why they were added to the language.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "resilience",
@@ -205,7 +227,8 @@
         "date": "2016-09-13",
         "place": "Main Stage",
         "summary": "<p>Web browsers have become so powerful that developers are now treating them as if they were a runtime environment as predictable as any other. But the truth is that we still need to deal with many unknown factors that torpedo our assumptions. The web is where Postel’s Law meets Murphy’s Law, so we can’t treat web development as if it were just another flavour of software. Instead we must work with the grain of the web.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": true
     },
     {
         "slug": "special-music-visuals-hardware",
@@ -215,7 +238,8 @@
         "date": "2016-09-13",
         "place": "Social Space",
         "summary": "<p>Welcome to { LiveJS : Berlin } where Ruth and Tim take you on a journey through audio apis, midi controllers, drum machines and neopixels. All with a visual show and live music from DJ Patrick, to help you relax after a day of amazing talks.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "dj-social",
@@ -225,7 +249,8 @@
         "date": "2016-09-13",
         "place": "Social Space",
         "summary": "<p>Spinning for our Social Hour</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "coping",
@@ -235,7 +260,8 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "<p>Over the past few years, several CSS methodologies and JavaScript frameworks have been released. In one year, we receive 32,120 business emails. Every weekday, we're active on Slack for 2 hours 15 minutes. Technology is moving fast, and constantly, there's so much going on. We constantly have to adapt in an ever-changing environment, while somehow still doing our job of building proper, functioning software to the latest tight-super-unrealistic deadline.</p><p>This talk will look at the human side of our daily work in technology. Together, we will examine which factors affect us physically and emotionally in our work. We'll learn how they lead to pressure, stress, self-consciousness and ultimately burnout, and we'll find out how to identify early warning signs of being affected. You'll leave with a realistic look at your own, human capabilities, and the knowledge of what you can do to take care of yourself while working on software.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": true
     },
     {
         "slug": "design-css",
@@ -245,7 +271,8 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "<p>We finally have the tools necessary to create amazing page designs on the web. Now we can art direct our layouts, leveraging the power and tradition of graphic design.</p><p>In this eye-opening talk, Jen will explore concrete examples of an incredible range of new possibilities. She’ll walk through a step-by-step design process for figuring out how to create a layout as unique as your content. You’ll learn how Flexbox, Grid, Shapes, Multicolumn, Viewport Units, and more can be combined together to revolutionize how you approach the page &mdash; any page.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "pwa",
@@ -255,14 +282,16 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "break",
         "title": "Break",
         "start": "11:00",
         "date": "2016-09-14",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "layout",
@@ -272,7 +301,8 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "<p>It is 2016. CSS is now 20 years old, and it has taken this long for us to get a true layout system designed for web pages and applications. A layout system, not based on hacking properties designed for something else entirely, but one that considers the reality of design for the web today.</p><p>In this talk I’ll introduce this new layout system, a system encompassing Flexbox, CSS Grid Layout and the Box Alignment Module. We’ll take a look at the mindset shift needed to really take advantage of these modules, and also consider what they mean in terms of accessibility and performance.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "compatibility",
@@ -282,7 +312,8 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "<p>What does it mean for JavaScript and CSS to be — or not to be — compatible with the web?</p><p>Is it possible for a site written today to continue to work in 10 years? Likewise, could existing code complicate adding language features or fixing mistakes in web APIs?</p><p>In this talk I'll discuss the issues that arise when browsers attempt to clean up the web platform, either by adding new language features and DOM APIs or removing old ones — while attempting to remain backwards compatible. I'll even talk about some controversial moves made by browsers to support non-standard (cough webkit prefixes) CSS and JS.</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "offline-first",
@@ -292,14 +323,16 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "<p>We learned a lot about the offline first concept in the past two years including Service Worker, CouchDB etc.</p><p>Did we do everything already to make our applications offline first? Is caching the resources enough? Did we answer all the questions already and if not… What are the new questions we need to answer?</p><p>In this talk, I’ll show you what has changed in the last few years, how people did adapt the concept and what are the best practices.</p><p>And most importantly, can offline first help to save lives?</p>",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "lunch",
         "title": "Lunch",
         "start": "13:00",
         "date": "2016-09-14",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "pwa-hack-corner-2",
@@ -308,7 +341,8 @@
         "date": "2016-09-14",
         "place": "Ground Floor: Discussion corner D - Saal (Social room)",
         "summary": "<p>Join us with Mozilla and Google in an open discussion session about progressive web apps and the future of the Web.</p>",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "diversity-in-tech-3",
@@ -317,7 +351,8 @@
         "date": "2016-09-14",
         "place": "1st Floor: Discussion corner A - (Atelier A)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "story-webvr-1",
@@ -326,7 +361,8 @@
         "date": "2016-09-14",
         "place": "2nd Floor: Discussion corner B - (Kubus)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "building-webvr-1",
@@ -335,7 +371,8 @@
         "date": "2016-09-14",
         "place": "4th Floor Discussion corner C (Studio C)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "2fa-wtf",
@@ -344,7 +381,8 @@
         "date": "2016-09-14",
         "place": "4th Floor Discussion corner E - (Studio B)",
         "summary": "Everyone is hacking everything. Everything is vulnerable. Your site, your users, even you. Are you worried about this? You should be! Don't worry, I'm not trying to scare you (that much). We have plenty of safeguards against attempts on our applications' user data. We all (hopefully) recognise Two Factor Auth (2FA) as one of those safeguards, but what actually goes on under the hood of 2FA? We'll take a look into generating one time passwords, implementing 2FA in web applications and the only real life compelling use case for QR codes. Together, we'll make the web a more secure place.",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "diversity-in-tech-4",
@@ -353,7 +391,8 @@
         "date": "2016-09-14",
         "place": "1st Floor: Discussion corner A - (Atelier A)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "story-webvr-2",
@@ -362,7 +401,8 @@
         "date": "2016-09-14",
         "place": "2nd Floor: Discussion corner B - (Kubus)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "building-webvr-2",
@@ -371,7 +411,8 @@
         "date": "2016-09-14",
         "place": "4th Floor Discussion corner C (Studio C)",
         "summary": "",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "developers-learn-design",
@@ -380,14 +421,16 @@
         "date": "2016-09-14",
         "place": "4th Floor Discussion corner E - (Studio B)",
         "summary": "<p>There has been a huge buzz in the last 1-2 years around the topic that \"Everyone should learn how to code\" and more specifically that \"Designers should learn how to code\". Why is this not happening the other way around? Can brainstorming, user research, personas and design thinking change the way we write software? Can we adopt the same army-knives used by design agencies and freelancers to speed up the development of Software or to better prioritise some features over others?</p>",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "break",
         "title": "Break",
         "start": "15:30",
         "date": "2016-09-14",
-        "feature": false
+        "feature": false,
+        "keynote": false
     },
     {
         "slug": "webvr",
@@ -397,7 +440,8 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "",
-        "feature": true
+        "feature": true,
+        "keynote": false
     },
     {
         "slug": "closing-keynote",
@@ -406,6 +450,7 @@
         "date": "2016-09-14",
         "place": "Main Stage",
         "summary": "Coming Soon",
-        "feature": false
+        "feature": false,
+        "keynote": true
     }
 ]

--- a/layouts/includes/session.html
+++ b/layouts/includes/session.html
@@ -1,4 +1,4 @@
-<div class="session" id="{{ session.slug }}">
+
     <div class="cols">
         <div class="col col-1"><strong>{{ session.start }}</strong></div>
 
@@ -19,7 +19,7 @@
         </div>
 
         <div class="col col-4">
-            <div class="session_details">
+            <div class="session_details {% if !session.speakers %}session_details-nopic{% endif %}">
                 <h4 class="session_head">
                     {% if session.speakers %}
                         <span class="session_speakers">
@@ -43,7 +43,10 @@
                         {% endif %}
                     </div>
                 {% endif %}
+                {% if session.place %}
+                    <div class="session_place">@ {{ session.place }}</div>
+                {% endif %}
             </div>
         </div>
     </div>
-</div>
+

--- a/layouts/schedule.html
+++ b/layouts/schedule.html
@@ -17,9 +17,15 @@
                     </h3>
 
                     {% if model.sessions.length > 0 %}
+                        {% set last_time = 0 %}
                         {% for session in model.sessions %}
                             {% if session.date == day %}
-                                {% include "includes/session.html" with session %}
+
+                                <div class="session {% if last_time == session.start %}session-sametime{% endif %} {% if session.keynote == true %}session-keynote{% endif %}"" id="{{ session.slug }}">
+                                    {% include "includes/session.html" with session %}
+                                </div>
+                                {% set last_time = session.start %}
+
                             {% endif %}
                         {% endfor %}
                     {% else %}

--- a/source/stylesheets/components/session.styl
+++ b/source/stylesheets/components/session.styl
@@ -18,10 +18,43 @@ session
 }
 
 .session {
+    position: relative;
     padding: $grid-gutter-width;
     margin-bottom: ($grid-gutter-width / 2);
     background-color: $berlin-background;
     @extends $clearfix
+}
+
+.session-sametime {
+    margin-top: ($grid-gutter-width / 2) * -1;
+}
+
+.session-keynote:before {
+  content: '★';
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: $grid-gutter-width;
+  width: $grid-gutter-width;
+  background-color: $berlin-dark;
+  color: #fff;
+  set-font-size(8px);
+  line-height: 1;
+}
+
+.session_head {
+    margin-bottom: 0;
+}
+
+.session_place {
+    line-height: $heading-line-height;
+}
+
+.session_summary {
+    margin-top: $grid-gutter-width;
 }
 
 .session_speakers {
@@ -67,19 +100,23 @@ button.session_title {
 }
 
 .session_cta {
-    color: $berlin-links;
+    color: $berlin-secondary;
 }
 
 .session_title {
 
-        &:hover,
-        &:focus,
-        &:active {
+    &:hover,
+    &:focus,
+    &:active {
 
-            .session_cta {
-                text-decoration: underline;
-            }
+        .session_cta {
+            text-decoration: underline;
         }
+    }
+}
+
+.session_details-nopic button.session_title {
+    max-width: 100%;
 }
 
 @media $media-query-320-and-up {


### PR DESCRIPTION
- Combines multiple sessions at same time into 1 "block"
- fixes width of session title when there is no accompanying speaker pic on small screens
- Adds link colour to "more" link
- Reduces white space beneath sessions with no summaries
- Add icon to keynotes and keynote field to JSON data