### PR TITLE
Remove og:url

### DIFF
--- a/layouts/includes/meta.html
+++ b/layouts/includes/meta.html
@@ -12,7 +12,6 @@
         <meta property="og:type" content="website">
         <meta property="og:site_name" content="View Source Conference">
         <meta property="og:locale" content="en_US">
-        <meta property="og:url" content="https://viewsourceconf.org{{ site_dir }}">
         <meta property="og:image" content="https://viewsourceconf.org/assets/images/{{ share_prefix }}_facebook.jpg">
         <meta property="og:title" content="{{ site_title }}">
         <meta property="og:description" content="View Source is a conference for front-end web developers. Our goal is to provide an in-depth, practical look at current and on-the-horizon technologies, with plenty of opportunities for conversation.">


### PR DESCRIPTION
`og:url` should always be the URL of the page being viewed. If it is not Facebook and other content platforms will interpret this as a redirect. For example, if I wanted to share a link on Facebook about a specific speaker, my tweet would end up linking to the ViewSource homepage and not the actual speaker page.

The easiest way to rectify this is to remove the `og:url`, but ideally this would be dynamic and contain the URL of the current page.