### PR TITLE
UI improvements for session groups

### DIFF
--- a/layouts/includes/groupdetails.html
+++ b/layouts/includes/groupdetails.html
@@ -1,7 +1,7 @@
 <div class="session_details session_details-nopic">
-    <h4 class="session_head">
+    <h5 class="session_head">
         <span class="session_title">{{ session.title }}</span>
-    </h4>
+    </h5>
     {% if session.summary %}
         <div id="{{ session.slug }}_summary" class="session_summary js-hidden">
             {% set inside = true %}

--- a/layouts/schedule.html
+++ b/layouts/schedule.html
@@ -23,18 +23,20 @@
                         <div class="session {% if time == 'All Day' %}session-allday{% endif %}">
                             {% if time_slot.sessions %}
                                 <div class="cols">
-                                    <div class="col col-1"><strong>{{ time }}</strong></div>
+                                    <div class="col col-1"><strong {% if time == 'All Day' %}class="session_time-allday"{% endif %}>{{ time }}</strong></div>
                                     <div class="col col-5">
                                         <h4 class="session_title session_title-group">{{ time_slot.title }}</h4>
-                                        {% for session_coords in time_slot.sessions %}
-                                            {% set session = false %}
-                                            {% for s in conference_sessions %}
-                                                {% if s.slug == session_coords.slug %}
-                                                    {% set session = s %}
-                                                {% endif %}
+                                        <div class="session_group">
+                                            {% for session_coords in time_slot.sessions %}
+                                                {% set session = false %}
+                                                {% for s in conference_sessions %}
+                                                    {% if s.slug == session_coords.slug %}
+                                                        {% set session = s %}
+                                                    {% endif %}
+                                                {% endfor %}
+                                                {% include "includes/groupdetails.html" %}
                                             {% endfor %}
-                                            {% include "includes/groupdetails.html" %}
-                                        {% endfor %}
+                                        </div>
                                     </div>
                                 </div>
 

--- a/source/data/berlin_sessions.yaml
+++ b/source/data/berlin_sessions.yaml
@@ -3,10 +3,10 @@
     title: Registration and Breakfast
 -
     slug: break
-    title: Break
+    title: Break and Demos
 -
     slug: lunch
-    title: Lunch
+    title: Lunch and Demos
 -
     slug: "early-registration"
     title: "Early Registration Pick Up"

--- a/source/stylesheets/components/session.styl
+++ b/source/stylesheets/components/session.styl
@@ -5,7 +5,9 @@ session
 ====================================================================== */
 
 .session_day {
+    margin-right: ($grid-gutter-width * -1) + 2px;
     margin-bottom: $grid-gutter-width * 2;
+    margin-left: ($grid-gutter-width * -1) + 2px;
 }
 
 .session_day_header {
@@ -61,9 +63,15 @@ session
     @extends $clearfix
 }
 
-.session-allday {
-    border: 2px solid $berlin-dark;
-    padding: $grid-gutter-width - 2px;
+.session_time-allday {
+    padding: 0 4px;
+    background-color: $berlin-dark;
+    color: #fff;
+}
+
+.session_group {
+    border-left: 2px solid $berlin-dark;
+    padding-left: $grid-gutter-width;
 }
 
 .session_head {
@@ -136,7 +144,7 @@ button.session_title {
 }
 
 .session_title-group {
-    margin-bottom: $grid-gutter-width * 2;
+    margin-bottom: $grid-gutter-width;
 }
 
 .session_cta {
@@ -202,6 +210,11 @@ button.session_title {
 @media $media-query-480-and-up {
     $session-pic-480 = 100px;
     $session-pic-space-480 = $session-pic-480 + $grid-gutter-width + 5px; // plus a little extra because buttons have weird widths
+
+    .session_day {
+        margin-left: 0;
+        margin-right: 0;
+    }
 
     .session_pic {
         width: $session-pic-480;


### PR DESCRIPTION
- session days fill screen on smallest mobile
- group get small indent from group heading
- Add "demos" to lunch and break descriptions
- group headings are h5s