### PR TITLE
Remove tidy, it's breaking the js

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,7 +16,6 @@ const models = require('metalsmith-models');
 const permalinks = require('metalsmith-permalinks');
 const serve = require('metalsmith-serve');
 const stylus = require('metalsmith-stylus');
-const tidy = require('metalsmith-html-tidy');
 const uglify = require('metalsmith-uglify');
 const watch = require('metalsmith-watch');
 
@@ -128,16 +127,6 @@ metalsmith(__dirname)
                 smartypants: true,
             },
             removeAttributeAfterwards: true,
-        }))
-        // Tidy HTML
-        .use(tidy({
-            tidyOptions: {
-                'indent-spaces': 4,
-                'quote-ampersand': false,
-                'coerce-endtags': false,
-                'drop-empty-elements': false,
-                'new-blocklevel-tags': ['svg', 'g', 'defs', 'path', 'polyline', 'line', 'polygon',],
-            },
         }))
         // Log global metadata, etc., to terminal.
         .use(devonly(dump))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "metalsmith-filenames": "^1.0.0",
     "metalsmith-fingerprint-ignore": "^1.1.2",
     "metalsmith-html-minifier": "^2.0.0",
-    "metalsmith-html-tidy": "^1.1.0",
     "metalsmith-ignore": "^0.1.2",
     "metalsmith-in-place": "^1.4.3",
     "metalsmith-json-to-files": "git+https://github.com/hoosteeno/metalsmith-json-to-files.git#7ac8d1ba836ae3b538e3e2792553cb797253f7d6",


### PR DESCRIPTION
After adding a new SVG include tidy has started breaking the javascript.
I can't tell what's going on but I'd rather have working JS than tidy
source.

We were using a version of tidy without support for SVG and hacking it
by adding the SVG elements to a "new element" list. Possibly this would
not be a problem if we updated our version of tidy.